### PR TITLE
Add command to upload metadata to Movey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,6 +1619,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "http"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2360,7 @@ dependencies = [
  "colored",
  "datatest-stable",
  "difference",
+ "home",
  "include_dir",
  "itertools 0.10.1",
  "move-binary-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b2f5d0ee456f3928812dfc8c6d9a1d592b98678f6d56db9b0cd2b7bc6c8db5"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
 dependencies = [
  "bytes 1.0.1",
  "memchr",
@@ -1548,7 +1548,7 @@ dependencies = [
  "strip-ansi-escapes",
  "target-spec",
  "toml",
- "toml_edit",
+ "toml_edit 0.10.1",
  "twox-hash",
 ]
 
@@ -2382,6 +2382,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "toml_edit 0.14.4",
  "walkdir",
  "workspace-hack",
 ]
@@ -5230,6 +5231,18 @@ dependencies = [
  "indexmap",
  "itertools 0.10.1",
  "kstring",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools 0.10.1",
+ "serde 1.0.130",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -53,7 +53,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "d4830ac690261d0b47f06e86d18c47eaa65d0184e576cf9b62c3a49b28cb876b"
 dependencies = [
  "nix 0.20.0",
  "tempfile",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -110,7 +110,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -329,6 +329,12 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
@@ -417,7 +423,7 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.14",
  "time",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -513,7 +519,7 @@ checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static 1.4.0",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -533,7 +539,7 @@ version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b2f5d0ee456f3928812dfc8c6d9a1d592b98678f6d56db9b0cd2b7bc6c8db5"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "memchr",
 ]
 
@@ -580,6 +586,22 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpuid-bool"
@@ -687,11 +709,11 @@ dependencies = [
  "bitflags",
  "crossterm_winapi 0.8.0",
  "libc",
- "mio",
+ "mio 0.7.13",
  "parking_lot 0.11.1",
  "signal-hook",
  "signal-hook-mio",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -703,11 +725,11 @@ dependencies = [
  "bitflags",
  "crossterm_winapi 0.9.0",
  "libc",
- "mio",
+ "mio 0.7.13",
  "parking_lot 0.11.1",
  "signal-hook",
  "signal-hook-mio",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -716,7 +738,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -725,7 +747,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -763,7 +785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
 dependencies = [
  "nix 0.23.1",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -911,7 +933,7 @@ checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
  "libc",
  "redox_users 0.3.5",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -931,7 +953,7 @@ checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
  "redox_users 0.4.0",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1002,6 +1024,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,7 +1071,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34c90e0a755da706ce0970ec0fa8cc48aabcc8e8efa1245336acf718dab06ffe"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "ethereum-types",
  "hash-db",
  "hash256-std-hasher",
@@ -1208,6 +1239,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1268,22 @@ name = "fst"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d79238883cf0307100b90aba4a755d8051a3182305dfe7f649a1e9dc0517006f"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
@@ -1316,7 +1378,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1443,6 +1505,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
+name = "h2"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 0.2.25",
+ "tokio-util",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "hakari"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,6 +1619,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "itoa 1.0.1",
+]
+
+[[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes 0.5.6",
+ "http",
+]
+
+[[package]]
+name = "httparse"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6330e8a36bd8c859f3fa6d9382911fbb7147ec39807f63b923933a247240b9ba"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
 name = "humansize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,6 +1671,43 @@ checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
 dependencies = [
  "humantime",
  "serde 1.0.130",
+]
+
+[[package]]
+name = "hyper"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa 0.4.7",
+ "pin-project",
+ "socket2",
+ "tokio 0.2.25",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes 0.5.6",
+ "hyper",
+ "native-tls",
+ "tokio 0.2.25",
+ "tokio-tls",
 ]
 
 [[package]]
@@ -1716,6 +1868,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
+
+[[package]]
 name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,6 +1932,16 @@ name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "kstring"
@@ -1922,6 +2099,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow 0.2.2",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,9 +2141,21 @@ checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
- "miow",
+ "miow 0.3.7",
  "ntapi",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -1940,7 +2164,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2153,7 +2377,9 @@ dependencies = [
  "once_cell",
  "read-write-set",
  "read-write-set-dynamic",
+ "reqwest",
  "serde 1.0.130",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "walkdir",
@@ -2500,7 +2726,7 @@ dependencies = [
  "shell-words",
  "simplelog",
  "tempfile",
- "tokio",
+ "tokio 1.9.0",
  "toml",
  "walkdir",
  "workspace-hack",
@@ -2530,7 +2756,7 @@ dependencies = [
  "serde 1.0.130",
  "serde_json",
  "tera",
- "tokio",
+ "tokio 1.9.0",
  "workspace-hack",
 ]
 
@@ -2886,7 +3112,25 @@ dependencies = [
  "parking_lot 0.10.2",
  "thiserror",
  "widestring",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static 1.4.0",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2894,6 +3138,17 @@ name = "nested"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
+
+[[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "nextest-config"
@@ -2986,7 +3241,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3155,6 +3410,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "ordered-float"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,7 +3458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3269,7 +3557,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.1.57",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3283,7 +3571,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.10",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3380,6 +3668,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3390,6 +3704,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
@@ -3951,7 +4271,43 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.10.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+dependencies = [
+ "base64",
+ "bytes 0.5.6",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static 1.4.0",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite 0.2.7",
+ "serde 1.0.130",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio 0.2.25",
+ "tokio-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
 ]
 
 [[package]]
@@ -3960,7 +4316,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "rustc-hex",
 ]
 
@@ -4061,10 +4417,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static 1.4.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -4191,6 +4580,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa 1.0.1",
+ "ryu",
+ "serde 1.0.130",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4278,7 +4679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6be9f7d5565b1483af3e72975e2dee33879b3b86bd48c0929fccf6585d79e65a"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4304,7 +4705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.7.13",
  "signal-hook",
 ]
 
@@ -4375,6 +4776,17 @@ dependencies = [
  "num 0.3.1",
  "pomelo",
  "structopt 0.3.25",
+]
+
+[[package]]
+name = "socket2"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4555,7 +4967,7 @@ dependencies = [
  "rand 0.8.4",
  "redox_syscall 0.2.10",
  "remove_dir_all",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4588,7 +5000,7 @@ checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
  "dirs 1.0.5",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4679,7 +5091,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4727,22 +5139,40 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static 1.4.0",
+ "memchr",
+ "mio 0.6.23",
+ "num_cpus",
+ "pin-project-lite 0.1.12",
+ "slab",
+]
+
+[[package]]
+name = "tokio"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
- "bytes",
+ "bytes 1.0.1",
  "libc",
  "memchr",
- "mio",
+ "mio 0.7.13",
  "num_cpus",
  "once_cell",
  "parking_lot 0.11.1",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "signal-hook-registry",
  "tokio-macros",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4754,6 +5184,30 @@ dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
  "syn 1.0.74",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio 0.2.25",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.1.12",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -4779,13 +5233,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
 name = "tracing"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
- "pin-project-lite",
+ "log",
+ "pin-project-lite 0.2.7",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -4808,6 +5269,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static 1.4.0",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -4850,6 +5321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
 name = "tui"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4868,7 +5345,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -4953,6 +5430,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5030,6 +5516,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5078,8 +5570,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi",
+ "winapi 0.3.9",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
 ]
 
 [[package]]
@@ -5101,6 +5603,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde 1.0.130",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -5117,6 +5621,18 @@ dependencies = [
  "quote 1.0.9",
  "syn 1.0.74",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -5166,6 +5682,12 @@ checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -5173,6 +5695,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -5186,7 +5714,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5196,6 +5724,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "workspace-hack"
 version = "0.1.0"
 dependencies = [
@@ -5203,7 +5740,7 @@ dependencies = [
  "block-buffer 0.9.0",
  "bstr",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "clap 2.33.3",
  "clap 3.1.8",
  "codespan-reporting",
@@ -5218,7 +5755,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "mio",
+ "mio 0.7.13",
  "num-traits 0.2.14",
  "plotters",
  "primitive-types",
@@ -5234,6 +5771,16 @@ dependencies = [
  "syn 1.0.74",
  "tiny-keccak",
  "tracing-core",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -23,6 +23,7 @@ walkdir = "2.3.1"
 codespan-reporting = "0.11.1"
 itertools = "0.10.0"
 serde_json = "1.0"
+toml_edit =  { version = "0.14.3", features = ["easy"] }
 
 bcs = "0.1.2"
 move-bytecode-verifier = { path = "../../move-bytecode-verifier" }

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -55,6 +55,7 @@ reqwest = { version = "0.10", features = ["blocking", "json"] }
 
 [dev-dependencies]
 datatest-stable = "0.1.1"
+home = "0.5.3"
 
 [[bin]]
 name = "move"

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -22,6 +22,7 @@ tempfile = "3.2.0"
 walkdir = "2.3.1"
 codespan-reporting = "0.11.1"
 itertools = "0.10.0"
+serde_json = "1.0"
 
 bcs = "0.1.2"
 move-bytecode-verifier = { path = "../../move-bytecode-verifier" }
@@ -49,6 +50,7 @@ move-errmapgen = { path = "../../move-prover/move-errmapgen" }
 move-bytecode-source-map = { path = "../../move-ir-compiler/move-bytecode-source-map" }
 move-bytecode-viewer = { path = "../move-bytecode-viewer" }
 workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+reqwest = { version = "0.10", features = ["blocking", "json"] }
 
 [dev-dependencies]
 datatest-stable = "0.1.1"

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -7,6 +7,7 @@ pub mod base;
 pub mod experimental;
 pub mod package;
 pub mod sandbox;
+pub mod utils;
 
 /// Default directory where saved Move resources live
 pub const DEFAULT_STORAGE_DIR: &str = "storage";

--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -418,7 +418,7 @@ pub fn handle_package_commands(
             }
             upload_request.total_files = total_files;
             upload_request.total_size = total_size;
-            upload_request.token = credential::get_registry_api_token(config.test_mode);
+            upload_request.token = credential::get_registry_api_token(config.test_mode)?;
 
             if config.test_mode {
                 fs::write(

--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -399,7 +399,7 @@ pub fn handle_package_commands(
                 if cfg!(debug_assertions) {
                     url = String::from("http://staging.movey.net/api/v1/post_package/");
                 } else {
-                    url = String::from("https://movey.net/api/v1/post_package/");
+                    url = String::from("https://www.movey.net/api/v1/post_package/");
                 }
                 let client = Client::new();
                 let response = client.post(&url).json(&upload_request).send().unwrap();

--- a/language/tools/move-cli/src/utils/credential.rs
+++ b/language/tools/move-cli/src/utils/credential.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use anyhow::{Result, Context, bail};
-use toml_edit::easy::Value;
+use toml_edit::easy::{Value};
 
 pub fn get_move_home_path(is_test_mode: bool) -> String {
     let mut home = std::env::var("MOVE_HOME").unwrap_or_else(|_| {
@@ -20,25 +20,113 @@ pub fn get_credential_path(is_test_mode: bool) -> String {
 }
 
 pub fn get_registry_api_token(is_test_mode: bool) -> Result<String> {
-    match get_api_token(is_test_mode) {
-        Ok(content) => Ok(content),
-        Err(_) => bail!("There seems to be an error with your Movey credential. \
+    if let Ok(content) = get_api_token(is_test_mode) {
+        Ok(content)
+    } else {
+        bail!("There seems to be an error with your Movey credential. \
             Please run `move login` and follow the instructions.")
     }
 }
 
 fn get_api_token(is_test_mode: bool) -> Result<String> {
-    let move_home = get_move_home_path(is_test_mode);
-    let credential_path = move_home.clone() + "/credential.toml";
+    let credential_path = get_credential_path(is_test_mode);
     
     let contents = fs::read_to_string(&credential_path)?;
     let mut toml: Value = contents.parse()?;
     let registry = toml.as_table_mut()
-        .context("None")?
+        .context("Error parsing credential.toml")?
         .get_mut("registry")
-        .context("None")?;
-    let token = registry.as_table_mut().context("None")?
+        .context("Error parsing credential.toml")?;
+    let token = registry.as_table_mut()
+        .context("Error parsing token")?
         .get_mut("token")
-        .context("None")?;
+        .context("Error parsing token")?;
     Ok(token.to_string().replace("\"", ""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use home::home_dir;
+    use std::env;
+    use std::fs::File;
+
+    fn setup_move_home() -> (String, String) {
+        let mut move_home = env::var("MOVE_HOME").unwrap_or_else(|_| {
+            env::var("HOME").unwrap_or_else(|_| {
+                let home_dir = home_dir().unwrap().to_string_lossy().to_string();
+                env::set_var("HOME", &home_dir);
+                home_dir
+            })
+        });
+        move_home.push_str("/.move/test");
+        let credential_path = move_home.clone() + "/credential.toml";
+
+        return (move_home, credential_path);
+    }
+
+    fn clean_up() {
+        let (move_home, _) = setup_move_home();
+        let _ = fs::remove_dir_all(move_home);
+    }
+
+    #[test]
+    fn get_api_token_works() {
+        let (move_home, credential_path) = setup_move_home();
+        
+        let _ = fs::create_dir_all(&move_home);
+        File::create(&credential_path).unwrap();
+
+        let content = "[registry]\ntoken = \"a sample token\"";
+        fs::write(&credential_path, content).unwrap();
+        
+        let token = get_api_token(true).unwrap();
+        assert!(token.contains("a sample token"));
+
+        clean_up()
+    }
+
+    #[test]
+    fn get_api_token_fails_if_there_is_no_move_home_directory() {
+        let (move_home, _) = setup_move_home();
+        let _ = fs::remove_dir_all(&move_home);
+        let token = get_api_token(true);
+        assert!(token.is_err());
+
+        clean_up()
+    }
+
+    #[test]
+    fn get_api_token_fails_if_there_is_no_credential_file() {
+        let (move_home, _) = setup_move_home();
+        let _ = fs::remove_dir_all(&move_home);
+        fs::create_dir_all(&move_home).unwrap();
+        let token = get_api_token(true);
+        assert!(token.is_err());
+
+        clean_up()
+    }
+
+    #[test]
+    fn get_api_token_fails_if_credential_file_is_in_wrong_format() {
+        let (move_home, credential_path) = setup_move_home();
+
+        let _ = fs::remove_dir_all(&move_home);
+        fs::create_dir_all(&move_home).unwrap();
+        File::create(&credential_path).unwrap();
+
+        let content = "[registry]\ntoken = a sample token";
+        fs::write(&credential_path, content).unwrap();
+
+        let token = get_api_token(true);
+        assert!(token.is_err());
+
+        let content = "[registry]\ntokens = \"a sample token\"";
+        fs::write(&credential_path, content).unwrap();
+
+        let token = get_api_token(true);
+        assert!(token.is_err());
+
+        clean_up()
+    }
 }

--- a/language/tools/move-cli/src/utils/credential.rs
+++ b/language/tools/move-cli/src/utils/credential.rs
@@ -1,0 +1,37 @@
+use std::fs;
+use toml_edit::easy::Value;
+
+pub fn get_move_home_path(is_test_mode: bool) -> String {
+    let mut home = std::env::var("MOVE_HOME").unwrap_or_else(|_| {
+        format!(
+            "{}/.move",
+            std::env::var("HOME").expect("env var 'HOME' must be set")
+        )
+    });
+    if is_test_mode && !home.contains("/test") {
+        home.push_str("/test");
+    }
+    home
+}
+
+pub fn get_credential_path(is_test_mode: bool) -> String {
+    get_move_home_path(is_test_mode) + "/credential.toml"
+}
+
+pub fn get_registry_api_token(is_test_mode: bool) -> String {
+    let move_home = get_move_home_path(is_test_mode);
+    let credential_path = move_home.clone() + "/credential.toml";
+    let contents = fs::read_to_string(&credential_path).expect("Unable to read credential.toml");
+    let mut toml: Value = contents.parse().expect("Unable to parse credential.toml");
+    let registry = toml
+        .as_table_mut()
+        .unwrap()
+        .get_mut("registry")
+        .expect("Unable to get [registry] table in credential.toml");
+    let token = registry
+        .as_table_mut()
+        .unwrap()
+        .get_mut("token")
+        .expect("Unable to get token");
+    token.to_string().replace("\"", "")
+}

--- a/language/tools/move-cli/src/utils/mod.rs
+++ b/language/tools/move-cli/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod credential;

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -1,7 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs;
+use std::env::home_dir;
+use std::fs::{self, File};
+use std::io::Write;
 use move_cli::sandbox::commands::test;
 
 use std::path::{Path, PathBuf};
@@ -108,6 +110,47 @@ fn upload_package_to_movey_with_no_head_commit_id_should_panic() {
     assert!(!output.status.success());
     let error = String::from_utf8_lossy(output.stderr.as_slice()).to_string();
     assert!(error.contains("invalid HEAD commit id"));
+}
+
+#[test]
+fn upload_package_to_movey_with_no_credential_should_panic() {
+    let home = home_dir().unwrap().to_string_lossy().to_string() + "/.move/test";
+    let credential_file = home.clone() + "/credential.toml";
+    let _ = fs::remove_file(&credential_file);
+    
+    init_git(PACKAGE_PATH, 0);
+    let output = Command::new(CLI_EXE)
+        .current_dir(PACKAGE_PATH)
+        .args(["package", "upload", "--test"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let error = String::from_utf8_lossy(output.stderr.as_slice()).to_string();
+    assert!(error.contains("There seems to be an error with your Movey credential. \
+        Please run `move login` and follow the instructions."));
+}
+
+#[test]
+fn upload_package_to_movey_with_bad_credential_should_panic() {
+    let home = home_dir().unwrap().to_string_lossy().to_string() + "/.move/test";
+    let credential_file = home.clone() + "/credential.toml";
+    let _ = fs::remove_file(&credential_file);
+    
+    fs::create_dir_all(&home).unwrap();
+    let mut file = File::create(&credential_file).unwrap();
+    let bad_content = String::from("[registry]\ntoken=\n");
+    file.write(&bad_content.as_bytes()).unwrap();
+
+    init_git(PACKAGE_PATH, 0);
+    let output = Command::new(CLI_EXE)
+        .current_dir(PACKAGE_PATH)
+        .args(["package", "upload", "--test"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let error = String::from_utf8_lossy(output.stderr.as_slice()).to_string();
+    assert!(error.contains("There seems to be an error with your Movey credential. \
+        Please run `move login` and follow the instructions."));
 }
 
 // flag == 0: all git command are run

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -47,13 +47,13 @@ fn cross_process_locking_git_deps() {
     #[cfg(not(debug_assertions))]
     const CLI_EXE: &str = "../../../../../../target/release/move";
     let handle = std::thread::spawn(|| {
-        std::process::Command::new(CLI_EXE)
+        Command::new(CLI_EXE)
             .current_dir("./tests/cross_process_tests/Package1")
             .args(["package", "build"])
             .output()
             .expect("Package1 failed");
     });
-    std::process::Command::new(CLI_EXE)
+    Command::new(CLI_EXE)
         .current_dir("./tests/cross_process_tests/Package2")
         .args(["package", "build"])
         .output()
@@ -77,11 +77,11 @@ fn upload_package_to_movey_works() {
         .unwrap();
     assert!(output.status.success());
     let res_path = format!("{}{}", PACKAGE_PATH, "/request-body.txt");
-    let data = std::fs::read_to_string(&res_path).unwrap();
+    let data = fs::read_to_string(&res_path).unwrap();
     assert!(data.contains("rev"));
     assert!(data.contains("\"github_repo_url\":\"https://github.com/diem/move\""));
     assert!(data.contains("\"description\":\"Description test\""));
-    std::fs::remove_file(&res_path).unwrap();
+    fs::remove_file(&res_path).unwrap();
 }
 
 #[test]

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -42,12 +42,14 @@ fn run_metatest() {
     assert!(test::run_all(&path_metatest, &path_cli_binary, true, false).is_ok());
 }
 
+const PACKAGE_PATH: &str = "./tests/upload_tests/valid_package";
+#[cfg(debug_assertions)]
+const CLI_EXE: &str = "../../../../../../target/debug/move";
+#[cfg(not(debug_assertions))]
+const CLI_EXE: &str = "../../../../../../target/release/move";
+
 #[test]
 fn cross_process_locking_git_deps() {
-    #[cfg(debug_assertions)]
-    const CLI_EXE: &str = "../../../../../../target/debug/move";
-    #[cfg(not(debug_assertions))]
-    const CLI_EXE: &str = "../../../../../../target/release/move";
     let handle = std::thread::spawn(|| {
         Command::new(CLI_EXE)
             .current_dir("./tests/cross_process_tests/Package1")
@@ -63,14 +65,18 @@ fn cross_process_locking_git_deps() {
     handle.join().unwrap();
 }
 
-const PACKAGE_PATH: &str = "./tests/upload_tests/valid_package";
-#[cfg(debug_assertions)]
-const CLI_EXE: &str = "../../../../../../target/debug/move";
-#[cfg(not(debug_assertions))]
-const CLI_EXE: &str = "../../../../../../target/release/move";
-
 #[test]
 fn upload_package_to_movey_works() {
+    let (home, credential_file) = setup_move_home();
+    let _ = fs::remove_file(&credential_file);
+
+    fs::create_dir_all(&home).unwrap();
+    let mut file = File::create(&credential_file).unwrap();
+    let credential_content = String::from(
+            "[registry]\ntoken=\"eb8xZkyr78FNL528j7q39zcdS6mxjBXt\"\n"
+    );
+    file.write(&credential_content.as_bytes()).unwrap();
+
     init_git(PACKAGE_PATH, 0);
     let output = Command::new(CLI_EXE)
         .current_dir(PACKAGE_PATH)
@@ -84,6 +90,8 @@ fn upload_package_to_movey_works() {
     assert!(data.contains("\"github_repo_url\":\"https://github.com/diem/move\""));
     assert!(data.contains("\"description\":\"Description test\""));
     fs::remove_file(&res_path).unwrap();
+
+    clean_up(&home);
 }
 
 #[test]
@@ -114,10 +122,9 @@ fn upload_package_to_movey_with_no_head_commit_id_should_panic() {
 
 #[test]
 fn upload_package_to_movey_with_no_credential_should_panic() {
-    let home = home_dir().unwrap().to_string_lossy().to_string() + "/.move/test";
-    let credential_file = home.clone() + "/credential.toml";
+    let (home, credential_file) = setup_move_home();
     let _ = fs::remove_file(&credential_file);
-    
+
     init_git(PACKAGE_PATH, 0);
     let output = Command::new(CLI_EXE)
         .current_dir(PACKAGE_PATH)
@@ -128,14 +135,15 @@ fn upload_package_to_movey_with_no_credential_should_panic() {
     let error = String::from_utf8_lossy(output.stderr.as_slice()).to_string();
     assert!(error.contains("There seems to be an error with your Movey credential. \
         Please run `move login` and follow the instructions."));
+
+    clean_up(&home);
 }
 
 #[test]
 fn upload_package_to_movey_with_bad_credential_should_panic() {
-    let home = home_dir().unwrap().to_string_lossy().to_string() + "/.move/test";
-    let credential_file = home.clone() + "/credential.toml";
+    let (home, credential_file) = setup_move_home();
     let _ = fs::remove_file(&credential_file);
-    
+
     fs::create_dir_all(&home).unwrap();
     let mut file = File::create(&credential_file).unwrap();
     let bad_content = String::from("[registry]\ntoken=\n");
@@ -151,6 +159,8 @@ fn upload_package_to_movey_with_bad_credential_should_panic() {
     let error = String::from_utf8_lossy(output.stderr.as_slice()).to_string();
     assert!(error.contains("There seems to be an error with your Movey credential. \
         Please run `move login` and follow the instructions."));
+
+    clean_up(&home);
 }
 
 // flag == 0: all git command are run
@@ -185,4 +195,14 @@ fn init_git(package_path: &str, flag: i32) {
             .args(&["commit", "-m", "initial commit"])
             .output().unwrap();
     }
+}
+
+fn clean_up(move_home: &str) {
+    let _ = fs::remove_dir_all(move_home);
+}
+
+fn setup_move_home() -> (String, String) {
+    let home = home_dir().unwrap().to_string_lossy().to_string() + "/.move/test";
+    let credential_file = home.clone() + "/credential.toml";
+    (home, credential_file)
 }

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -1,10 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env::home_dir;
+use home::home_dir;
+use move_cli::sandbox::commands::test;
 use std::fs::{self, File};
 use std::io::Write;
-use move_cli::sandbox::commands::test;
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -72,9 +72,8 @@ fn upload_package_to_movey_works() {
 
     fs::create_dir_all(&home).unwrap();
     let mut file = File::create(&credential_file).unwrap();
-    let credential_content = String::from(
-            "[registry]\ntoken=\"eb8xZkyr78FNL528j7q39zcdS6mxjBXt\"\n"
-    );
+    let credential_content =
+        String::from("[registry]\ntoken=\"eb8xZkyr78FNL528j7q39zcdS6mxjBXt\"\n");
     file.write(&credential_content.as_bytes()).unwrap();
 
     init_git(PACKAGE_PATH, 0);
@@ -88,7 +87,6 @@ fn upload_package_to_movey_works() {
     let data = fs::read_to_string(&res_path).unwrap();
     assert!(data.contains("rev"));
     assert!(data.contains("\"github_repo_url\":\"https://github.com/diem/move\""));
-    assert!(data.contains("\"description\":\"Description test\""));
     fs::remove_file(&res_path).unwrap();
 
     clean_up(&home);
@@ -133,8 +131,10 @@ fn upload_package_to_movey_with_no_credential_should_panic() {
         .unwrap();
     assert!(!output.status.success());
     let error = String::from_utf8_lossy(output.stderr.as_slice()).to_string();
-    assert!(error.contains("There seems to be an error with your Movey credential. \
-        Please run `move login` and follow the instructions."));
+    assert!(error.contains(
+        "There seems to be an error with your Movey credential. \
+        Please run `move login` and follow the instructions."
+    ));
 
     clean_up(&home);
 }
@@ -157,8 +157,10 @@ fn upload_package_to_movey_with_bad_credential_should_panic() {
         .unwrap();
     assert!(!output.status.success());
     let error = String::from_utf8_lossy(output.stderr.as_slice()).to_string();
-    assert!(error.contains("There seems to be an error with your Movey credential. \
-        Please run `move login` and follow the instructions."));
+    assert!(error.contains(
+        "There seems to be an error with your Movey credential. \
+        Please run `move login` and follow the instructions."
+    ));
 
     clean_up(&home);
 }
@@ -174,26 +176,31 @@ fn init_git(package_path: &str, flag: i32) {
     Command::new("git")
         .current_dir(package_path)
         .args(&["init"])
-        .output().unwrap();
+        .output()
+        .unwrap();
     if flag != 1 {
         Command::new("git")
             .current_dir(package_path)
             .args(&["remote", "add", "origin", "git@github.com:diem/move.git"])
-            .output().unwrap();
+            .output()
+            .unwrap();
     }
     Command::new("touch")
         .current_dir(package_path)
         .args(&["simplefile"])
-        .output().unwrap();
+        .output()
+        .unwrap();
     Command::new("git")
         .current_dir(package_path)
         .args(&["add", "simplefile"])
-        .output().unwrap();
-    if flag != 2{
+        .output()
+        .unwrap();
+    if flag != 2 {
         Command::new("git")
             .current_dir(package_path)
             .args(&["commit", "-m", "initial commit"])
-            .output().unwrap();
+            .output()
+            .unwrap();
     }
 }
 

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -1,9 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fs;
 use move_cli::sandbox::commands::test;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 pub const CLI_METATEST_PATH: [&str; 3] = ["tests", "metatests", "args.txt"];
 
@@ -57,4 +59,87 @@ fn cross_process_locking_git_deps() {
         .output()
         .expect("Package2 failed");
     handle.join().unwrap();
+}
+
+const PACKAGE_PATH: &str = "./tests/upload_tests/valid_package";
+#[cfg(debug_assertions)]
+const CLI_EXE: &str = "../../../../../../target/debug/move";
+#[cfg(not(debug_assertions))]
+const CLI_EXE: &str = "../../../../../../target/release/move";
+
+#[test]
+fn upload_package_to_movey_works() {
+    init_git(PACKAGE_PATH, 0);
+    let output = Command::new(CLI_EXE)
+        .current_dir(PACKAGE_PATH)
+        .args(["package", "upload", "--test"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let res_path = format!("{}{}", PACKAGE_PATH, "/request-body.txt");
+    let data = std::fs::read_to_string(&res_path).unwrap();
+    assert!(data.contains("rev"));
+    assert!(data.contains("\"github_repo_url\":\"https://github.com/diem/move\""));
+    assert!(data.contains("\"description\":\"Description test\""));
+    std::fs::remove_file(&res_path).unwrap();
+}
+
+#[test]
+fn upload_package_to_movey_with_no_remote_should_panic() {
+    init_git(PACKAGE_PATH, 1);
+    let output = Command::new(CLI_EXE)
+        .current_dir(PACKAGE_PATH)
+        .args(["package", "upload", "--test"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let error = String::from_utf8_lossy(output.stderr.as_slice()).to_string();
+    assert!(error.contains("invalid git repository"));
+}
+
+#[test]
+fn upload_package_to_movey_with_no_head_commit_id_should_panic() {
+    init_git(PACKAGE_PATH, 2);
+    let output = Command::new(CLI_EXE)
+        .current_dir(PACKAGE_PATH)
+        .args(["package", "upload", "--test"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let error = String::from_utf8_lossy(output.stderr.as_slice()).to_string();
+    assert!(error.contains("invalid HEAD commit id"));
+}
+
+// flag == 0: all git command are run
+// flag == 1: missing git add remote command
+// flag == 2: missing git commit command
+fn init_git(package_path: &str, flag: i32) {
+    let git_path = format!("{}{}", package_path, "/.git");
+    if Path::new::<String>(&git_path).exists() {
+        fs::remove_dir_all(&git_path).unwrap();
+    }
+    Command::new("git")
+        .current_dir(package_path)
+        .args(&["init"])
+        .output().unwrap();
+    if flag != 1 {
+        Command::new("git")
+            .current_dir(package_path)
+            .args(&["remote", "add", "origin", "git@github.com:diem/move.git"])
+            .output().unwrap();
+    }
+    Command::new("touch")
+        .current_dir(package_path)
+        .args(&["simplefile"])
+        .output().unwrap();
+    Command::new("git")
+        .current_dir(package_path)
+        .args(&["add", "simplefile"])
+        .output().unwrap();
+    if flag != 2{
+        Command::new("git")
+            .current_dir(package_path)
+            .args(&["commit", "-m", "initial commit"])
+            .output().unwrap();
+    }
 }

--- a/language/tools/move-cli/tests/upload_tests/valid_package/Move.toml
+++ b/language/tools/move-cli/tests/upload_tests/valid_package/Move.toml
@@ -1,7 +1,6 @@
 [package]
 name = "Package1"
 version = "0.0.0"
-description = "Description test"
 
 [addresses]
 Std = "0x1"

--- a/language/tools/move-cli/tests/upload_tests/valid_package/Move.toml
+++ b/language/tools/move-cli/tests/upload_tests/valid_package/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "Package1"
+version = "0.0.0"
+description = "Description test"
+
+[addresses]
+Std = "0x1"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/diem/move.git", subdir = "language/move-stdlib", rev = "98ed299" }

--- a/language/tools/move-cli/tests/upload_tests/valid_package/sources/Dummy.move
+++ b/language/tools/move-cli/tests/upload_tests/valid_package/sources/Dummy.move
@@ -1,0 +1,1 @@
+module 0x1::Dummy {}


### PR DESCRIPTION
## Motivation

Add `move package upload` command to upload move package to [Movey](https://www.movey.net/), modify `move package build` command to call Movey API to increase download count.

### How to use it
Before you use the new command to upload metadata to Movey, please make sure:
* your package must be on Github
* the remote must be named “origin”
* file $HOME/.move/credential.toml must exist, and the content should be like: 
```
[registry]
token = "cwagbNajttYGWjKymJdn9n2nq4yOYIpT"
```
Note: you could use the `move login` command from this [PR](https://github.com/ea-open-source/move/pull/3) to save your Movey's api token using the CLI.

Step 1: Navigate to the folder containing your package.
Step 2: Run the following command:
`move package upload`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test --package move-cli --test cli_tests upload_package -- --test-threads 1
cargo test --package move-cli --lib get_api_token -- --test-threads 1